### PR TITLE
Fix issue when using crossref in the browser with browser-request

### DIFF
--- a/source.js
+++ b/source.js
@@ -8,7 +8,7 @@ const timeout = 60 * 1000; // CrossRef is *very* slow
 // make a request
 function GET (path, cb) {
   // console.log(`### ${endpoint}${path}`);
-  request(`${endpoint}${path}`, { json: true, timeout }, (err, res, body) => {
+  request({ url: `${endpoint}${path}`, json: true, timeout }, (err, res, body) => {
     if (err || !res || res.statusCode >= 400) {
       let statusCode = res ? res.statusCode : 0
         , statusMessage = res ? res.statusMessage : 'Unspecified error (likely a timeout)'


### PR DESCRIPTION
When using crossref with webpack/babel in the browser, I get the following error from request: 
`Uncaught Error: Bad callback given: [object Object]`

It could be unique to my configuration, but webpack (or, more likely, one of my loaders?) automatically trues to swap request for browser-request, which then spits out an error when crossref makes a request.

In any case, moving the URL into the options object fixes the issue in the browser and also works while using vanilla request in node.

Thanks!