### PR TITLE
Handle 429 errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "homepage": "https://github.com/scienceai/crossref",
   "devDependencies": {
     "ava": "0.16.0",
+    "babel-cli": "^6.18.0",
     "babel-core": "6.18.0",
     "babel-preset-es2015": "6.18.0",
     "babelify": "7.3.0",

--- a/source.js
+++ b/source.js
@@ -10,9 +10,15 @@ function GET (path, cb) {
   // console.log(`### ${endpoint}${path}`);
   request({ url: `${endpoint}${path}`, json: true, timeout }, (err, res, body) => {
     if (err || !res || res.statusCode >= 400) {
-      let statusCode = res ? res.statusCode : 0
-        , statusMessage = res ? res.statusMessage : 'Unspecified error (likely a timeout)'
-      ;
+      let statusCode = res ? res.statusCode : 0;
+      let statusMessage = res ? res.statusMessage : 'Unspecified error (likely a timeout)';
+
+      if (statusCode === 429) {
+        let headers  = res.headers || {};
+        let limit    = headers['x-rate-limit-limit'] || 'N/A';
+        let interval = headers['x-rate-limit-interval'] || 'N/A';
+        return cb(new Error(`Rate limit exceeded: ${limit} requests in ${interval}`));
+      }
       if (statusCode === 404) return cb(new Error(`Not found on CrossRef: '${endpoint}${path}'`));
       let msg = (err && err.message) ? err.message : statusMessage;
       return cb(new Error(`CrossRef error: [${statusCode}] ${msg}`));

--- a/source.js
+++ b/source.js
@@ -10,13 +10,15 @@ function GET (path, cb) {
   // console.log(`### ${endpoint}${path}`);
   request({ url: `${endpoint}${path}`, json: true, timeout }, (err, res, body) => {
     if (err || !res || res.statusCode >= 400) {
-      let statusCode = res ? res.statusCode : 0;
-      let statusMessage = res ? res.statusMessage : 'Unspecified error (likely a timeout)';
+      let statusCode = res ? res.statusCode : 0
+        , statusMessage = res ? res.statusMessage : 'Unspecified error (likely a timeout)'
+      ;
 
       if (statusCode === 429) {
-        let headers  = res.headers || {};
-        let limit    = headers['x-rate-limit-limit'] || 'N/A';
-        let interval = headers['x-rate-limit-interval'] || 'N/A';
+        let headers = res.headers || {}
+          , limit = headers['x-rate-limit-limit'] || 'N/A'
+          , interval = headers['x-rate-limit-interval'] || 'N/A'
+        ;
         return cb(new Error(`Rate limit exceeded: ${limit} requests in ${interval}`));
       }
       if (statusCode === 404) return cb(new Error(`Not found on CrossRef: '${endpoint}${path}'`));


### PR DESCRIPTION
Hi there !

My team is using this module to make a lot of requests to crossref, but we have no way to determine the rate limit. This pull request adds an explicit error message for `429` errors, with the content of `X-Rate-Limit-Limit` and `X-Rate-Limit-Interval`.

Ideally I would prefer to have access to the response headers for each query, but I'm not sure how it should be implemented, since the callbacks already have plenty of arguments.

I also added **babel-cli** in the `package.json`.